### PR TITLE
Added clock icon as pikatime default.

### DIFF
--- a/pikatime.php
+++ b/pikatime.php
@@ -13,6 +13,7 @@ class PikatimeField extends InputField {
   public function input() {
     $input = parent::input();
     $input->data("field", "pikatime");
+    $this->icon = "clock-o";
     
     if (isset($this->mode))
       $input->data("mode", $this->mode());


### PR DESCRIPTION
It felt a little weird that that the pikatime fields didn't have a clock icon while both the `date` and `time` fields have icons by default, so I added a default clock icon to the structure.
